### PR TITLE
[Update omni_streamlit.py]：Fix: Add sys.path to omni_streamlit.py for correct utils import

### DIFF
--- a/webui/omni_streamlit.py
+++ b/webui/omni_streamlit.py
@@ -13,6 +13,13 @@ import tempfile
 import librosa
 import traceback
 from pydub import AudioSegment
+import sys
+
+# 获取项目的根目录
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+# 将项目根目录添加到 sys.path
+sys.path.append(project_root)
+
 from utils.vad import get_speech_timestamps, collect_chunks, VadOptions
 
 


### PR DESCRIPTION
解决ModuleNotFoundError: No module named 'utils'。因为 utils 模块在项目中的路径不在 Python 的默认搜索路径中，可以手动添加路径。例如，在 omni_streamlit.py 文件顶部添加代码。